### PR TITLE
Move Codable conformance out of struct def

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorProfile.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorProfile.swift
@@ -71,63 +71,47 @@ extension AppBskyLexicon.Actor {
 
         /// The date and time the profile was created. Optional.
         public let createdAt: Date?
-        
-        public init(
-            displayName: String? = nil,
-            description: String? = nil,
-            avatarBlob: ComAtprotoLexicon.Repository.UploadBlobOutput? = nil,
-            bannerBlob: ComAtprotoLexicon.Repository.UploadBlobOutput? = nil,
-            labels: [ComAtprotoLexicon.Label.SelfLabelsDefinition]? = nil,
-            joinedViaStarterPack: ComAtprotoLexicon.Repository.StrongReference? = nil,
-            pinnedPost: ComAtprotoLexicon.Repository.StrongReference? = nil,
-            createdAt: Date? = nil
-        ) {
-            self.displayName = displayName
-            self.description = description
-            self.avatarBlob = avatarBlob
-            self.bannerBlob = bannerBlob
-            self.labels = labels
-            self.joinedViaStarterPack = joinedViaStarterPack
-            self.pinnedPost = pinnedPost
-            self.createdAt = createdAt
-        }
+    }
+}
 
-        public init(from decoder: any Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
+//defining Codable in an extension allows swift to automatically synthsize
+//the memberwise initializer 
+extension AppBskyLexicon.Actor.ProfileRecord: Codable {
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
 
-            self.displayName = try container.decodeIfPresent(String.self, forKey: .displayName)
-            self.description = try container.decodeIfPresent(String.self, forKey: .description)
-            self.avatarBlob = try container.decodeIfPresent(ComAtprotoLexicon.Repository.UploadBlobOutput.self, forKey: .avatarBlob)
-            self.bannerBlob = try container.decodeIfPresent(ComAtprotoLexicon.Repository.UploadBlobOutput.self, forKey: .bannerBlob)
-            self.labels = try container.decodeIfPresent([ComAtprotoLexicon.Label.SelfLabelsDefinition].self, forKey: .labels)
-            self.joinedViaStarterPack = try container.decodeIfPresent(ComAtprotoLexicon.Repository.StrongReference.self, forKey: .joinedViaStarterPack)
-            self.pinnedPost = try container.decodeIfPresent(ComAtprotoLexicon.Repository.StrongReference.self, forKey: .pinnedPost)
-            self.createdAt = try container.decodeDateIfPresent(forKey: .createdAt)
-        }
+        self.displayName = try container.decodeIfPresent(String.self, forKey: .displayName)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.avatarBlob = try container.decodeIfPresent(ComAtprotoLexicon.Repository.UploadBlobOutput.self, forKey: .avatarBlob)
+        self.bannerBlob = try container.decodeIfPresent(ComAtprotoLexicon.Repository.UploadBlobOutput.self, forKey: .bannerBlob)
+        self.labels = try container.decodeIfPresent([ComAtprotoLexicon.Label.SelfLabelsDefinition].self, forKey: .labels)
+        self.joinedViaStarterPack = try container.decodeIfPresent(ComAtprotoLexicon.Repository.StrongReference.self, forKey: .joinedViaStarterPack)
+        self.pinnedPost = try container.decodeIfPresent(ComAtprotoLexicon.Repository.StrongReference.self, forKey: .pinnedPost)
+        self.createdAt = try container.decodeDateIfPresent(forKey: .createdAt)
+    }
 
-        public func encode(to encoder: any Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
 
-            try container.encodeIfPresent(self.displayName, forKey: .displayName)
-            try container.encodeIfPresent(self.description, forKey: .description)
-            try container.encodeIfPresent(self.avatarBlob, forKey: .avatarBlob)
-            try container.encodeIfPresent(self.bannerBlob, forKey: .bannerBlob)
-            try container.encodeIfPresent(self.labels, forKey: .labels)
-            try container.encodeIfPresent(self.joinedViaStarterPack, forKey: .joinedViaStarterPack)
-            try container.encodeIfPresent(self.pinnedPost, forKey: .pinnedPost)
-            try container.encodeDateIfPresent(self.createdAt, forKey: .createdAt)
-        }
+        try container.encodeIfPresent(self.displayName, forKey: .displayName)
+        try container.encodeIfPresent(self.description, forKey: .description)
+        try container.encodeIfPresent(self.avatarBlob, forKey: .avatarBlob)
+        try container.encodeIfPresent(self.bannerBlob, forKey: .bannerBlob)
+        try container.encodeIfPresent(self.labels, forKey: .labels)
+        try container.encodeIfPresent(self.joinedViaStarterPack, forKey: .joinedViaStarterPack)
+        try container.encodeIfPresent(self.pinnedPost, forKey: .pinnedPost)
+        try container.encodeDateIfPresent(self.createdAt, forKey: .createdAt)
+    }
 
-        enum CodingKeys: String, CodingKey {
-            case type = "$type"
-            case displayName
-            case description
-            case avatarBlob = "avatar"
-            case bannerBlob = "banner"
-            case labels
-            case joinedViaStarterPack
-            case pinnedPost
-            case createdAt
-        }
+    enum CodingKeys: String, CodingKey {
+        case type = "$type"
+        case displayName
+        case description
+        case avatarBlob = "avatar"
+        case bannerBlob = "banner"
+        case labels
+        case joinedViaStarterPack
+        case pinnedPost
+        case createdAt
     }
 }

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorProfile.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorProfile.swift
@@ -74,9 +74,10 @@ extension AppBskyLexicon.Actor {
     }
 }
 
-//defining Codable in an extension allows swift to automatically synthsize
-//the memberwise initializer 
+// Implementing Codable conformance in an extension allows Swift to automatically
+// synthesize the memberwise initializer
 extension AppBskyLexicon.Actor.ProfileRecord: Codable {
+
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoPutRecord.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoPutRecord.swift
@@ -17,7 +17,7 @@ extension ComAtprotoLexicon.Repository {
     /// - SeeAlso: This is based on the [`com.atproto.repo.putRecord`][github] lexicon.
     ///
     /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/repo/putRecord.json
-    public struct PutRecordRequestBody: Sendable, Codable {
+    public struct PutRecordRequestBody: Sendable {
 
         /// The decentralized identifier (DID) or handle of the repository.
         ///
@@ -72,24 +72,6 @@ extension ComAtprotoLexicon.Repository {
             case swapRecord
             case swapCommit
         }
-        
-        public init(
-           repository: String,
-           collection: String,
-           recordKey: String,
-           shouldValidate: Bool? = true,
-           record: UnknownType,
-           swapRecord: String? = nil,
-           swapCommit: String? = nil
-       ) {
-           self.repository = repository
-           self.collection = collection
-           self.recordKey = recordKey
-           self.shouldValidate = shouldValidate
-           self.record = record
-           self.swapRecord = swapRecord
-           self.swapCommit = swapCommit
-       }
     }
 
     /// A output model for creating a record that replaces a previous record.
@@ -125,3 +107,8 @@ extension ComAtprotoLexicon.Repository {
         }
     }
 }
+
+//defining the codable extension in an extension allows the memberwise
+//initializer to be generated automatically
+//https://stackoverflow.com/questions/48155118/explit-conformance-to-codable-removes-memberwise-initializer-generation-on-struc
+extension ComAtprotoLexicon.Repository.PutRecordRequestBody: Codable {}

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoPutRecord.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoPutRecord.swift
@@ -108,7 +108,7 @@ extension ComAtprotoLexicon.Repository {
     }
 }
 
-//defining the codable extension in an extension allows the memberwise
-//initializer to be generated automatically
-//https://stackoverflow.com/questions/48155118/explit-conformance-to-codable-removes-memberwise-initializer-generation-on-struc
+// Defining the Codable conformance in an extension allows the memberwise
+// initializer to be generated automatically
+// https://stackoverflow.com/questions/48155118/explit-conformance-to-codable-removes-memberwise-initializer-generation-on-struc
 extension ComAtprotoLexicon.Repository.PutRecordRequestBody: Codable {}


### PR DESCRIPTION
Move Codable conformances out of the struct definition, which will allow public memberwise initializers to be automatically defined for us, so we don't need to declare our own.